### PR TITLE
fix punch not affecting Ranged AI & fix punch animation glitch

### DIFF
--- a/Content/Unbread/Art/Characters/GingerbreadMan/GBM_Throw2.uasset
+++ b/Content/Unbread/Art/Characters/GingerbreadMan/GBM_Throw2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:833b1de9ead826680ab760b8f41c6a781a8b0c7fa293a109a6b3b98c98a72998
-size 87176
+oid sha256:fbb734b39c0a5acdaa08c5e02282b1b58c4e3af9550f3c26a646dc29709e9838
+size 87155

--- a/Content/Unbread/Core/Character/BP_Character.uasset
+++ b/Content/Unbread/Core/Character/BP_Character.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:855aea8baa023b87ac94ce8228b48e360138701d6524a9645d8fe42b6516ae9b
-size 729116
+oid sha256:fe0abd642aff58c6377c73971cfddc42ede955ebacbd28e33f0ffaa93735e0d1
+size 754668

--- a/Content/Unbread/Environment/Interactables/VentFan/Fan.uasset
+++ b/Content/Unbread/Environment/Interactables/VentFan/Fan.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cedf62ac87e3db7ecad78c9e5c50e8bc4d8304a68b584085fff248494ec1d7e
-size 57953
+oid sha256:897ce90e50b77e15a8cf3c4f99ddb437651116aff847386645283ed7bd922bbc
+size 58965

--- a/Content/Unbread/Maps/CoreLevelTest.umap
+++ b/Content/Unbread/Maps/CoreLevelTest.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43b50ecb51c12413b938420a2263ebc0d3f8fad3f2780b3295929037fb966f6b
-size 1424063
+oid sha256:37eadd06a347f2506c9b7e757384a3bd518ed4ffd48dd26cc951a4dc6bc2cfc3
+size 1426388

--- a/Source/unbread/Private/SInteractionComponent.cpp
+++ b/Source/unbread/Private/SInteractionComponent.cpp
@@ -56,7 +56,7 @@ void USInteractionComponent::MeleeInteract()
 			FRotator Correction (0.0f, 90.0f, 0.f);
 			FRotator CorrecterRotation = EyeRotation + Correction;
 			FVector End = EyeLocation + (CorrecterRotation.Vector() * 300);
-			End.Z += 100.0f;
+			End.Z = EyeLocation.Z;
 			// FHitResult Hit;
 			// bool bBlockingHit = GetWorld()->LineTraceSingleByObjectType(Hit, EyeLocation, End, ObjectQueryParams);
 


### PR DESCRIPTION
### WHAT
fix Punch animation glitch and punch not applying to RangedAI

### WHY
core component of the game

### HOW
changed raycasting (line trace) method from visibility to object, defined objects to be interacted with and ignored, added multiple controlled delays to ensure punch animation doesn't trigger before the effects are applied